### PR TITLE
Implements shortcode to display Table of Contents

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -46,3 +46,9 @@ pygmentsCodefences = true
 
 [sitemap]
   filename = "sitemap.xml"  # c.f. https://gohugo.io/templates/sitemap-template/#configure-sitemap-xml
+
+[markup] 
+  [markup.tableOfContents]  # c.f. https://gohugo.io/getting-started/configuration-markup/#table-of-contents
+    startLevel = 2
+    endLevel = 3
+    ordered = false

--- a/exampleSite/content/post/tableofcontents.md
+++ b/exampleSite/content/post/tableofcontents.md
@@ -1,0 +1,43 @@
++++
+author = "Hugo Authors"
+title = "Custom Shortcode provided by Inkblotty"
+date = "2021-02-11"
+description = "Sample article insert table of contents."
+tags = [
+    "custom shortcodes",
+]
+categories = [
+    "themes",
+    "syntax",
+]
+archives = "2021/02"
+#series = ["Themes Guide"]
++++
+Inkblotty provides custom shortcode.
+
+<!--more-->
+
+## Table Of Contents
+### Configuration
+config.toml:
+``` toml
+[markup]
+  [markup.tableOfContents]
+    startLevel = 2
+    endLevel = 3
+    ordered = false
+```
+
+- **startLevel**: The heading level, values starting at 2 (h2), to start render the table of contents.
+- **endLevel**: The heading level, inclusive, to stop render the table of contents.
+
+**c.f.** https://gohugo.io/getting-started/configuration-markup/#table-of-contents
+
+### Markdown Sample
+CODE:
+```
+{{</* toc */>}}
+```
+
+PREVIEW:
+{{< toc >}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,6 +20,7 @@
     <link rel='stylesheet' href='{{ "css/style.css" | absURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/custom.css" | absURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/syntax.css" | absURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/toc.css" | absURL }}' type='text/css' media='all' />
     {{ template "_internal/google_analytics.html" . }}
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/shortcodes/toc.html
+++ b/layouts/shortcodes/toc.html
@@ -1,0 +1,12 @@
+<div class=toc-box>
+<div class=toc-label>
+{{ if eq .Site.LanguageCode "ja" }}
+    {{ printf "目次"}}
+{{ else }}
+    {{ printf "Contents"}}
+{{ end }}
+</div>
+<div class="toc-chapter">
+{{- .Page.TableOfContents -}}
+</div>
+</div>

--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -3,7 +3,7 @@
     border: 1px solid #000000;
     padding: 1em;
     width:max-content;
-    font-size: 95;
+    font-size: 95%;
 }
 
 .toc-label{

--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -1,0 +1,25 @@
+  /* メニューの修飾 */
+.toc-box{
+    border: 1px solid #000000;
+    padding: 1em;
+    width:max-content;
+    font-size: 95;
+}
+
+.toc-label{
+    text-align: center;
+    margin-top: 0px;
+    padding: 0px 6px 0 6px;
+    font-weight: bold;
+}
+
+#TableOfContents ul > li  {
+    display: block;
+    text-align: left;
+    list-style-type: none;
+}
+
+#TableOfContents ul >li >ul >li {
+    padding-left: 1em;
+    list-style-type: none;
+}


### PR DESCRIPTION
Issue #9に記載した目次表示用のcustom shortcodeを実装しました。

exmapleSitesに使用例を説明する記事を追加しています。

ローカル環境で動作確認しましたが、問題なく動くことを確認したので、チェックお願いします。