### PR TITLE
目次追加用shorcodeの実装

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -46,3 +46,9 @@ pygmentsCodefences = true
 
 [sitemap]
   filename = "sitemap.xml"  # c.f. https://gohugo.io/templates/sitemap-template/#configure-sitemap-xml
+
+[markup] 
+  [markup.tableOfContents]  # c.f. https://gohugo.io/getting-started/configuration-markup/#table-of-contents
+    startLevel = 2
+    endLevel = 3
+    ordered = false

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,9 +17,9 @@
             padding: 0 !important;
         }
     </style>
-    <link rel='stylesheet' href='{{ "css/style.css" | absURL }}' type='text/css' media='all' />
-    <link rel='stylesheet' href='{{ "css/custom.css" | absURL }}' type='text/css' media='all' />
-    <link rel='stylesheet' href='{{ "css/syntax.css" | absURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/style.css" | relURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/custom.css" | relURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/syntax.css" | relURL }}' type='text/css' media='all' />
     {{ template "_internal/google_analytics.html" . }}
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/shortcodes/toc.html
+++ b/layouts/shortcodes/toc.html
@@ -1,0 +1,12 @@
+<div class="toc-box">
+<div class="toc-label">
+{{ if eq .Site.LanguageCode "ja" }}
+    {{ printf "目次"}}
+{{ else }}
+    {{ printf "Contents"}}
+{{ end }}
+</div>
+<div class="toc-chapter">
+{{- .Page.TableOfContents -}}
+</div>
+</div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -71,22 +71,6 @@ nav.pagination .current {
     color: #000000;
 }
 
-.post-content h2 {
-    border-left: 6px solid #ff6347;
-    border-bottom: 1px solid #d1d1d1;
-    padding-left: 4px;
-}
-
-.post-content h3 {
-    border-left: 4px solid #4169e1;
-    border-bottom: 1px solid #d1d1d1;
-    padding-left: 6px;
-}
-
-.post-content h4 {
-    padding-left: 0px;
-}
-
 div.breadcrumbs {
     font-size: 80%;
     padding: 20px 0 0 20px;
@@ -117,3 +101,58 @@ iframe {
         display: none;
     }
 }
+
+.post-content h1 {
+    border-left: 8px solid #ff6347;
+    border-bottom: 1px solid #d1d1d1;
+    padding-left: 4px;
+}
+
+.post-content h2 {
+    border-left: 6px solid #4169e1;
+    border-bottom: 1px solid #d1d1d1;
+    padding-left: 6px;
+}
+
+.post-content h3 {
+    border-left: 4px solid #000000;
+    border-bottom: 1px solid #d1d1d1;
+    padding-left: 8px;
+}
+
+.post-content h4 {
+    padding-left: 0px;
+}
+
+/* Table of Contents Style */
+
+.toc-box{
+    border: 1px solid #000000;
+    padding: 1em;
+    width:max-content;
+    font-size: 95%;
+}
+
+.toc-label{
+    text-align: center;
+    margin-top: 0px;
+    padding: 0px 6px 0 6px;
+    font-weight: bold;
+}
+
+.toc-chapter #TableOfContents ul > li  {
+    display: block;
+    text-align: left;
+    list-style-type: none;
+}
+
+.toc-chapter #TableOfContents ul >li >ul >li {
+    padding-left: 1em;
+    list-style-type: none;
+}
+
+.toc-chapter #TableOfContents ul >li >ul >li >ul >li {
+    padding-left: 1em;
+    list-style-type: none;
+}
+


### PR DESCRIPTION
プルリク #10で不具合があったため、修正して出し直します。 

Issue #9に記載した目次表示用のcustom shortcodeを実装しました。

exmapleSitesに使用例を説明する記事を追加しています。

ローカル環境と当方のblogでの動作を確認済みです。

目次表示例：https://blog.rkarsnk.jp/post/2021/01/07/s3toamplify3/
