### PR TITLE
目次追加用shortcodesの実装。

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,9 +17,9 @@
             padding: 0 !important;
         }
     </style>
-    <link rel='stylesheet' href='{{ "css/style.css" | absURL }}' type='text/css' media='all' />
-    <link rel='stylesheet' href='{{ "css/custom.css" | absURL }}' type='text/css' media='all' />
-    <link rel='stylesheet' href='{{ "css/syntax.css" | absURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/style.css" | relURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/custom.css" | relURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/syntax.css" | relURL }}' type='text/css' media='all' />
     {{ template "_internal/google_analytics.html" . }}
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,6 +20,7 @@
     <link rel='stylesheet' href='{{ "css/style.css" | relURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/custom.css" | relURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/syntax.css" | relURL }}' type='text/css' media='all' />
+    <link rel='stylesheet' href='{{ "css/toc.css" | relURL }}' type='text/css' media='all' />
     {{ template "_internal/google_analytics.html" . }}
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/shortcodes/toc.html
+++ b/layouts/shortcodes/toc.html
@@ -1,0 +1,13 @@
+<div class="toc-box">
+    <div class="toc-label">
+    {{ if eq .Site.LanguageCode "ja" }}
+        {{ printf "目次"}}
+    {{ else }}
+        {{ printf "Contents"}}
+    {{ end }}
+    </div>
+    <div class="toc-chapter">
+    {{- .Page.TableOfContents -}}
+    </div>
+</div>
+

--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -1,0 +1,31 @@
+/* Table of Contents Style */
+
+.toc-box{
+    border: 1px solid #000000;
+    padding: 1em;
+    width:max-content;
+    font-size: 95%;
+}
+
+.toc-label{
+    text-align: center;
+    margin-top: 0px;
+    padding: 0px 6px 0 6px;
+    font-weight: bold;
+}
+
+.toc-chapter #TableOfContents ul > li  {
+    display: block;
+    text-align: left;
+    list-style-type: none;
+}
+
+.toc-chapter #TableOfContents ul >li >ul >li {
+    padding-left: 1em;
+    list-style-type: none;
+}
+
+.toc-chapter #TableOfContents ul >li >ul >li >ul >li {
+    padding-left: 1em;
+    list-style-type: none;
+}


### PR DESCRIPTION
たびたびプルリクだしてすいません。正式版のプルリクエストです。
以下の変更を行っています。

### スタイルシート参照の方法をabsURLからrelURLに変更
GitHubプルリク提出チェック時に、テーマギャラリー用のNetlifyのURLを参照していたため、修正しました。

### 目次への対応
`{{< toc >}}`を記事中に追加することで、Wikipediaライクの目次が任意の場所に挿入されます。

### 目次の設定方法
exampleSiteにサンプルポストを作成しようとしていましたが、Hugoのテンプレートのフォーマットから
逸脱するようなので、サンプルポストの作成は取り下げました。

config.tomlに以下を追記することでh1からh3までの目次を生成できます。
```
[markup] 
  	[markup.tableOfContents] 
    	startLevel = 1
    	endLevel = 3
    	ordered = false
```
h2からの目次を作成する場合は、`startLevel = 2`に変更すれば、h1は無視されます。

目次の設置例は、こちらをご覧ください。
https://blog.rkarsnk.jp/post/2020/12/31/s3toamplify/

以上、よろしくお願いします。