### PR TITLE
favicon対応

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
         }
     </style>
     {{ if (fileExists "static/favicon.ico") -}}
-    <link rel='icon' href="favicon.ico" />
+    <link rel='icon' href="/favicon.ico" />
     {{- end }}
     <link rel='stylesheet' href='{{ "css/style.css" | relURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/custom.css" | relURL }}' type='text/css' media='all' />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
         }
     </style>
     {{ if (fileExists "static/favicon.ico") -}}
-    <link rel='icon' herf="favicon.ico" />
+    <link rel='icon' href="favicon.ico" />
     {{- end }}
     <link rel='stylesheet' href='{{ "css/style.css" | relURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/custom.css" | relURL }}' type='text/css' media='all' />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,6 +17,9 @@
             padding: 0 !important;
         }
     </style>
+    {{ if (fileExists "static/favicon.ico") -}}
+    <link rel='icon' herf="favicon.ico" />
+    {{- end }}
     <link rel='stylesheet' href='{{ "css/style.css" | relURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/custom.css" | relURL }}' type='text/css' media='all' />
     <link rel='stylesheet' href='{{ "css/syntax.css" | relURL }}' type='text/css' media='all' />


### PR DESCRIPTION
favicon対応の修正しました。

staticフォルダにICO形式の`favicon.ico`を保存すれば、自動的にfaviconが適用されます。 
Issue #14 でアドバイスいただいたの参考に、head.htmlに追記しました。

プルリク内にfavicon.icoは用意してないので、検証の時は別途ご用意ください。

apple-touch-iconについては未対応です。