### PR TITLE
Support enabling ToC by Frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ There are two ways to show a table of contents:
 This is sample configuration of TOC in `config.toml`
 ```
 [markup]
-        [markup.tableOfContents]
-        startLevel = 1
-        endLevel = 3
-        ordered = false
+    [markup.tableOfContents]
+    startLevel = 1
+    endLevel = 3
+    ordered = false
 ```
 If you set `startLevel = 2`, `<h1>` tag is ignored.
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ There are two ways to show a table of contents:
 This is sample configuration of TOC in `config.toml`
 ```
 [markup]
-        [markup.tableOfContents]
-        startLevel = 1
-        endLevel = 3
-        ordered = false
+  [markup.tableOfContents]
+    startLevel = 1
+    endLevel = 3
+    ordered = false
 ```
 If you set `startLevel = 2`, `<h1>` tag is ignored.
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ There are two ways to show a table of contents:
 This is sample configuration of TOC in `config.toml`
 ```
 [markup]
-    [markup.tableOfContents]
-    startLevel = 1
-    endLevel = 3
-    ordered = false
+        [markup.tableOfContents]
+        startLevel = 1
+        endLevel = 3
+        ordered = false
 ```
 If you set `startLevel = 2`, `<h1>` tag is ignored.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Inkblotty is a Hugo theme based on [Inkblot](https://github.com/mgsisk/inkblot).
   - Share Button (Facebook, Twitter, Hatena Bookmark)
   - Comment form (Disqus)
   - Related Posts
-  - Table of Contents by shortcode
+  - Table of Contents (front matter or shortcode)
 - Article list
   - Summarize and Readmore
 - Sidebar
@@ -39,19 +39,21 @@ Inkblotty is a Hugo theme based on [Inkblot](https://github.com/mgsisk/inkblot).
 [exampleSite/config.toml](https://github.com/tosi29/inkblotty/blob/master/exampleSite/config.toml) is for reference.
 
 ### Table of Contents
-This theme has shortcode to create Table of Contents.  
-To insert Table of Contents, write the following code in markdown.
-```
-{{< toc >}}
-```
+There are two ways to show a table of contents:
+
+- Set `toc: true` in the page front matter to automatically render the table of contents near the top of the article.
+- Insert the shortcode manually where you want the table of contents to appear:
+  ```
+  {{< toc >}}
+  ```
 
 This is sample configuration of TOC in `config.toml`
 ```
-[markup] 
-  	[markup.tableOfContents] 
-    	startLevel = 1
-    	endLevel = 3
-    	ordered = false
+[markup]
+        [markup.tableOfContents]
+        startLevel = 1
+        endLevel = 3
+        ordered = false
 ```
 If you set `startLevel = 2`, `<h1>` tag is ignored.
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,6 +17,10 @@
             </div>
         </header>
 
+        {{ if .Params.toc }}
+        {{ partial "toc.html" . }}
+        {{ end }}
+
         <div class="post-content">
             {{ .Content }}
         </div>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,12 @@
+<div class="toc-box">
+    <div class="toc-label">
+    {{ if eq .Site.LanguageCode "ja" }}
+        {{ printf "目次"}}
+    {{ else }}
+        {{ printf "Contents"}}
+    {{ end }}
+    </div>
+    <div class="toc-chapter">
+    {{- .Page.TableOfContents -}}
+    </div>
+</div>

--- a/layouts/shortcodes/toc.html
+++ b/layouts/shortcodes/toc.html
@@ -1,13 +1,2 @@
-<div class="toc-box">
-    <div class="toc-label">
-    {{ if eq .Site.LanguageCode "ja" }}
-        {{ printf "目次"}}
-    {{ else }}
-        {{ printf "Contents"}}
-    {{ end }}
-    </div>
-    <div class="toc-chapter">
-    {{- .Page.TableOfContents -}}
-    </div>
-</div>
+{{ partial "toc.html" . }}
 


### PR DESCRIPTION
## Summary
- extract the table of contents markup into a reusable partial
- reuse the partial from both the single page layout and the toc shortcode to keep output consistent

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195f464750832385ea3128916b2e91)