### PR TITLE
Use RelPermalink for sidebar links

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -6,7 +6,7 @@
         <ul class="widget__list">
             {{- range $name, $items := .Site.Taxonomies.categories -}}
             <li class="cat-item cat-item-2">
-                <a href="{{- .Page.Permalink -}}">{{ .Page.Title }} ({{ $items.Count }})</a>
+                <a href="{{- .Page.RelPermalink -}}">{{ .Page.Title }} ({{ $items.Count }})</a>
             </li>
             {{- end }}
         </ul>
@@ -16,7 +16,7 @@
         <h2>{{ T "tags_title" }}</h2>
         <div class="tagcloud">
             {{- range $name, $items := .Site.Taxonomies.tags -}}
-            <a class="tag-cloud-link" href="{{- .Page.Permalink -}}" title="{{ $name }}" style="font-size: 12pt;">{{ .Page.Title }}</a>&emsp;
+            <a class="tag-cloud-link" href="{{- .Page.RelPermalink -}}" title="{{ $name }}" style="font-size: 12pt;">{{ .Page.Title }}</a>&emsp;
             {{- end }}
         </div>
     </aside>
@@ -37,7 +37,7 @@
         <h2>{{ T "archives_title" }}</h2>
         <ul>
             {{- range $name, $items := .Site.Taxonomies.archives -}}
-            <li><a href="{{- .Page.Permalink -}}">{{ .Page.Title }} ({{ $items.Count }})</a></li>
+            <li><a href="{{- .Page.RelPermalink -}}">{{ .Page.Title }} ({{ $items.Count }})</a></li>
             {{- end }}
         </ul>
     </aside>


### PR DESCRIPTION
## Summary
- サイドバーのカテゴリ、タグ、アーカイブのリンクで `Permalink` を `RelPermalink` に変更
- プレビューサイト（localhost、Cloudflare Pagesプレビュー等）でもリンクが正しく動作するように修正

## Test plan
- [ ] `hugo server` でローカルプレビューを起動し、サイドバーのリンクが相対パスになっていることを確認
- [ ] カテゴリ、タグ、アーカイブのリンクをクリックして正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)