### PR TITLE
Use RelPermalink for summary links

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,7 +1,7 @@
 <article class="list__item post clearfix">
 	{{- if .Params.thumbnail }}
 	<figure class="list__thumbnail">
-		<a href="{{ .Permalink }}">
+		<a href="{{ .RelPermalink }}">
 			<img src="{{ .Params.thumbnail | relURL }}" alt="{{ .Title }}" />
 		</a>
 	</figure>
@@ -41,7 +41,7 @@
 		<span class="post-categories">
 			{{- range $all_categories -}}
 				{{ if in $categories .Page.Title }}
-				<a href="{{- .Page.Permalink -}}">{{ .Page.Title }}</a>&emsp;
+				<a href="{{- .Page.RelPermalink -}}">{{ .Page.Title }}</a>&emsp;
 				{{ end }}
 			{{- end }}
 		</span>
@@ -53,7 +53,7 @@
 		<span class="post-tags">
 			{{- range $all_tags -}}
 				{{ if in $tags .Page.Title }}
-				<a href="{{- .Page.Permalink -}}">{{ .Page.Title }}</a>&emsp;
+				<a href="{{- .Page.RelPermalink -}}">{{ .Page.Title }}</a>&emsp;
 				{{ end }}
 			{{- end }}
 		</span>


### PR DESCRIPTION
## Summary
- 記事一覧（summary.html）のサムネイル、カテゴリ、タグのリンクで `Permalink` を `RelPermalink` に変更
- プレビューサイト（localhost、Cloudflare Pagesプレビュー等）でもリンクが正しく動作するように修正

## Test plan
- [ ] `hugo server` でローカルプレビューを起動
- [ ] 記事一覧ページでサムネイル、カテゴリ、タグのリンクが相対パスになっていることを確認
- [ ] 各リンクをクリックして正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)