### PR TITLE
Use RelPermalink for single page links

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -34,7 +34,7 @@
                 <span class="post-categories">
                     {{- range $all_categories -}}
                         {{ if in $categories .Page.Title }}
-                        <a href="{{- .Page.Permalink -}}">{{ .Page.Title }}</a>&emsp;
+                        <a href="{{- .Page.RelPermalink -}}">{{ .Page.Title }}</a>&emsp;
                         {{ end }}
                     {{- end }}
                 </span>
@@ -46,7 +46,7 @@
                 <span class="post-tags">
                     {{- range $all_tags -}}
                         {{ if in $tags .Page.Title }}
-                        <a href="{{- .Page.Permalink -}}">{{ .Page.Title }}</a>&emsp;
+                        <a href="{{- .Page.RelPermalink -}}">{{ .Page.Title }}</a>&emsp;
                         {{ end }}
                     {{- end }}
                 </span>
@@ -61,12 +61,12 @@
         <div class="nav-links">
             <div class="nav-previous">
                 {{ with .PrevInSection }}
-                <a class="previous" href="{{.Permalink}}"> {{.Title}}</a>
+                <a class="previous" href="{{.RelPermalink}}"> {{.Title}}</a>
                 {{ end }}
             </div>
             <div class="nav-next">
                 {{ with .NextInSection }}
-                <a class="next" href="{{.Permalink}}"> {{.Title}}</a>
+                <a class="next" href="{{.RelPermalink}}"> {{.Title}}</a>
                 {{ end }}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- 記事ページ（single.html）のカテゴリ、タグ、前後記事ナビゲーションのリンクで `Permalink` を `RelPermalink` に変更
- プレビューサイト（localhost、Cloudflare Pagesプレビュー等）でもリンクが正しく動作するように修正

## Test plan
- [ ] `hugo server` でローカルプレビューを起動
- [ ] 記事ページでカテゴリ、タグのリンクが相対パスになっていることを確認
- [ ] 前の記事・次の記事のリンクが相対パスになっていることを確認
- [ ] 各リンクをクリックして正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)